### PR TITLE
Update for v113.0 and match scrollbar colours to FlyingFox theme

### DIFF
--- a/chrome/icons/icons.css
+++ b/chrome/icons/icons.css
@@ -229,7 +229,7 @@ toolbarbutton[class="bookmark-item"][container="true"] > .toolbarbutton-icon {
 
 .tab-icon-image[src="chrome://browser/skin/settings.svg"] ~ .tab-icon-overlay
 {
-    display: -moz-box !important;
+    display: flex !important;
     margin: 0 !important;
     list-style-image: url(settings.svg) !important;
     -moz-context-properties: fill, fill-opacity !important;

--- a/chrome/navbar/navbar.css
+++ b/chrome/navbar/navbar.css
@@ -110,7 +110,7 @@ toolbar:not([customizing="true"])
 /* show "Private" label for en languages only */
 :root[titlemodifier="(Private Browsing)"] #fxa-toolbar-menu-button::before {
     content: "Private" !important;
-    display: -moz-box !important;
+    display: flex !important;
     margin-inline-start: 12px !important;
     margin-inline-end: 6px !important;
 }

--- a/chrome/popup/popup.css
+++ b/chrome/popup/popup.css
@@ -148,7 +148,7 @@ scrollbox[orient=vertical] /* >=71 */ {
 /* this is a bit depressing... */
 /* work around lack of ::part selector support */
 :root {
-    --scrollbutton-display: -moz-box !important;
+    --scrollbutton-display: flex !important;
 }
 
 /* hide ancient-looking scrollbuttons in menupopups */
@@ -342,7 +342,7 @@ panelview .toolbarbutton-1,
 }
 
 :root[fxastatus="signedin"] #appMenu-fxa-label > .toolbarbutton-icon {
-    display: -moz-box !important;
+    display: flex !important;
     border-radius: 99px !important;
     padding: 2px !important;
 }
@@ -413,7 +413,7 @@ panelmultiview .toolbaritem-combined-buttons > spacer.after-label {
 
 #tracking-protection-preferences-button > .toolbarbutton-text {
     padding-inline-end: 4px !important;
-    -moz-box-ordinal-group: 0 !important;
+    order: 0 !important;
 }
 
 .identity-popup-section {
@@ -434,8 +434,8 @@ panelmultiview .toolbaritem-combined-buttons > spacer.after-label {
     width: 32px !important;
     max-height: 32px !important;
     margin-inline-start: auto !important;
-    -moz-box-pack: center !important;
-    -moz-box-align: center !important;
+    justify-content: center !important;
+    align-items: center !important;
     background-image: none !important;
 }
 
@@ -463,7 +463,7 @@ panelmultiview .toolbaritem-combined-buttons > spacer.after-label {
 }
 
 #identity-popup-mainView-panel-header {
-    -moz-box-align: start !important;
+    align-items: start !important;
     padding: 16px !important;
 }
 
@@ -765,7 +765,7 @@ panelmultiview .toolbaritem-combined-buttons > spacer.after-label {
     content: url(checkmark.svg) !important;
     -moz-context-properties: fill, fill-opacity !important;
     fill: currentColor !important;
-    display: -moz-box !important;
+    display: flex !important;
     width: 18px !important;
     height: 18px !important;
     margin-inline-start: 16px !important;

--- a/chrome/urlbar/urlbar.css
+++ b/chrome/urlbar/urlbar.css
@@ -148,7 +148,7 @@
     background-clip: padding-box !important;
     text-align: center;
     transition: background-color 0.1s var(--ease-basic);
-    -moz-box-align: center !important;
+    align-items: center !important;
     display: block !important;
     padding-bottom: 0px !important;
     top: 0px !important;
@@ -174,7 +174,7 @@
     background-clip: padding-box !important;
     text-align: center;
     transition: background-color 0.1s var(--ease-basic);
-    -moz-box-align: center !important;
+    align-items: center !important;
     display: block !important;
     padding-bottom: 0px !important;
     top: 0 !important;
@@ -346,7 +346,7 @@
 #urlbar[pageproxystate="valid"]
     #identity-box:-moz-any(.mixedActiveBlocked, .mixedDisplayContentLoadedActiveBlocked, .mixedActiveContent)
     > #connection-icon {
-    display: -moz-box !important;
+    display: flex !important;
 }
 
 #urlbar[pageproxystate="valid"]

--- a/chrome/userContent.css
+++ b/chrome/userContent.css
@@ -60,3 +60,6 @@
     }
 
   }
+
+:root{   
+  scrollbar-color: var(--light-1) var(--dark-base) !important; }


### PR DESCRIPTION
@Astromations These are all the files I could find that containec any `-mozbox` css. 

Just a heads up, before merging I'm not sure whether the lines with `justify-content` or `align-items` should be `justify-items` and `align-content` instead. The [reddit ](https://www.reddit.com/r/FirefoxCSS/comments/11odffm/psa_incoming_changes_to_default_element/) post it depends on what the line is for, but [here ](https://groups.google.com/a/mozilla.org/g/firefox-dev/c/9sGpF1TNbLk/m/QpU3oTUuAgAJ?pli=1)it follows what I have changed. 

I could use some help with that. 

Also updated scrollbar colours to follow the theme better. 